### PR TITLE
Upgrade to spigot 1.14.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.lynxplay</groupId>
     <artifactId>serena</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Serena
 main: me.ravvenlord.serena.Serena
 version: "1.0"
-api-version: "1.13"
+api-version: "1.14"
 
 commands:
   serena:


### PR DESCRIPTION
This commit upgrades the spigot api dependency to spigot 1.14.4.
This includes the api-version in the plugin.yml being set to "1.14".
This was also reflected in the maven version, which was bumped to 1.0.2.