### PR TITLE
Implement a banned entity set to serena logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.lynxplay</groupId>
     <artifactId>serena</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.0.6-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,7 +53,7 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>deploy</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
@@ -67,23 +67,9 @@
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
-                        <phase>deploy</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <executions>
-                    <execution>
-                        <id>deploy</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>deploy</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/dev/lynxplay/serena/configuration/properties/ImmutablePropertyConfiguration.java
+++ b/src/main/java/dev/lynxplay/serena/configuration/properties/ImmutablePropertyConfiguration.java
@@ -1,15 +1,22 @@
 package dev.lynxplay.serena.configuration.properties;
 
+import org.bukkit.entity.EntityType;
+
 import java.time.Duration;
+import java.util.EnumSet;
+import java.util.Set;
 
 public class ImmutablePropertyConfiguration implements PropertyConfiguration {
 
     private final Duration playerPickupCooldown;
     private final double throwVelocityMultiplier;
+    private final Set<EntityType> bannedEntityTypes;
 
-    ImmutablePropertyConfiguration(Duration playerPickupCooldown, double throwVelocityMultiplier) {
+    ImmutablePropertyConfiguration(Duration playerPickupCooldown, double throwVelocityMultiplier,
+                                   Set<EntityType> bannedEntityTypes) {
         this.playerPickupCooldown = playerPickupCooldown;
         this.throwVelocityMultiplier = throwVelocityMultiplier;
+        this.bannedEntityTypes = bannedEntityTypes;
     }
 
     /**
@@ -30,6 +37,18 @@ public class ImmutablePropertyConfiguration implements PropertyConfiguration {
     @Override
     public double throwVelocityMultiplier() {
         return throwVelocityMultiplier;
+    }
+
+    /**
+     * Provides a set containing all entity types that are banned from being picked up by serena.
+     * An entity type that is listed in the set cannot be picked up or thrown off the player by serena.
+     *
+     * @return the set instance. The set is mutable but is not backed by this configuration, hence modifications to the
+     * set will not modify this configuration instance.
+     */
+    @Override
+    public Set<EntityType> bannedEntityTypes() {
+        return EnumSet.copyOf(bannedEntityTypes);
     }
 
 }

--- a/src/main/java/dev/lynxplay/serena/configuration/properties/ImmutablePropertyConfigurationFactory.java
+++ b/src/main/java/dev/lynxplay/serena/configuration/properties/ImmutablePropertyConfigurationFactory.java
@@ -2,9 +2,16 @@ package dev.lynxplay.serena.configuration.properties;
 
 import dev.lynxplay.serena.configuration.ConfigurationFactory;
 import org.bukkit.configuration.Configuration;
+import org.bukkit.entity.EntityType;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ImmutablePropertyConfigurationFactory implements ConfigurationFactory<PropertyConfiguration> {
 
@@ -17,9 +24,18 @@ public class ImmutablePropertyConfigurationFactory implements ConfigurationFacto
      */
     @Override
     public PropertyConfiguration create(Configuration configuration) {
+        final Map<String, EntityType> keyList = Arrays.stream(EntityType.values())
+            .filter(t -> t != EntityType.UNKNOWN)
+            .collect(Collectors.toMap(t -> t.getKey().getKey(), Function.identity()));
+        final EnumSet<EntityType> bannedEntityTypes = configuration.getStringList("banned-entity-types").stream()
+            .map(keyList::get)
+            .filter(Objects::nonNull)
+            .collect(() -> EnumSet.noneOf(EntityType.class), EnumSet::add, EnumSet::addAll);
+
         return new ImmutablePropertyConfiguration(
             Duration.of(configuration.getLong("player-pickup-cooldown", 10L), ChronoUnit.SECONDS),
-            configuration.getDouble("player-throw-multiplier", 1)
+            configuration.getDouble("player-throw-multiplier", 1),
+            bannedEntityTypes
         );
     }
 

--- a/src/main/java/dev/lynxplay/serena/configuration/properties/PropertyConfiguration.java
+++ b/src/main/java/dev/lynxplay/serena/configuration/properties/PropertyConfiguration.java
@@ -1,6 +1,9 @@
 package dev.lynxplay.serena.configuration.properties;
 
+import org.bukkit.entity.EntityType;
+
 import java.time.Duration;
+import java.util.Set;
 
 /**
  * The {@link PropertyConfiguration} defines a configuration that contains the properties of this plugin
@@ -20,5 +23,14 @@ public interface PropertyConfiguration {
      * @return the double value
      */
     double throwVelocityMultiplier();
+
+    /**
+     * Provides a set containing all entity types that are banned from being picked up by serena.
+     * An entity type that is listed in the set cannot be picked up or thrown off the player by serena.
+     *
+     * @return the set instance. The set is mutable but is not backed by this configuration, hence modifications to the
+     *     set will not modify this configuration instance.
+     */
+    Set<EntityType> bannedEntityTypes();
 
 }

--- a/src/main/java/dev/lynxplay/serena/listener/PlayerPickupListener.java
+++ b/src/main/java/dev/lynxplay/serena/listener/PlayerPickupListener.java
@@ -48,6 +48,7 @@ public class PlayerPickupListener implements Listener {
 
         Entity target = event.getRightClicked();
         if (!(target instanceof LivingEntity)) return;
+        if (this.propertyConfiguration.bannedEntityTypes().contains(target.getType())) return;
 
         Duration durationLeft = this.cooldownContainer.getCooldownLeft(player.getUniqueId()).orElse(null);
         if (durationLeft != null) {

--- a/src/main/java/dev/lynxplay/serena/listener/PlayerThrowListener.java
+++ b/src/main/java/dev/lynxplay/serena/listener/PlayerThrowListener.java
@@ -3,6 +3,7 @@ package dev.lynxplay.serena.listener;
 import dev.lynxplay.serena.FixedScheduler;
 import dev.lynxplay.serena.configuration.properties.PropertyConfiguration;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -10,6 +11,8 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public class PlayerThrowListener implements Listener {
 
@@ -26,11 +29,13 @@ public class PlayerThrowListener implements Listener {
         if (event.getAction() != Action.LEFT_CLICK_AIR) return;
 
         Player player = event.getPlayer();
-        ArrayList<Entity> passengers = new ArrayList<>(player.getPassengers());
+        final List<Entity> passengers = new ArrayList<>(player.getPassengers());
+        final Set<EntityType> bannedEntityTypes = this.propertyConfiguration.bannedEntityTypes();
+        passengers.removeIf(e -> bannedEntityTypes.contains(e.getType()));
 
         if (passengers.isEmpty()) return;
 
-        player.eject();
+        passengers.forEach(player::removePassenger);
         scheduler.runTaskDelayed(() -> passengers.forEach(e -> e.setVelocity(player.getLocation()
                 .getDirection()
                 .multiply(this.propertyConfiguration.throwVelocityMultiplier())

--- a/src/main/resources/properties.yml
+++ b/src/main/resources/properties.yml
@@ -6,3 +6,9 @@ player-pickup-cooldown: 10
 
 # The multiplier applied when a player launches a picked up entity
 player-throw-multiplier: 1
+
+# A list of minecraft entity types that may not be interacted with through serena
+# The full list of minecraft entity types is available here:
+# https://minecraft.gamepedia.com/Java_Edition_data_value/Pre-flattening/Entity_IDs
+banned-entity-types:
+  - 'armor_stand'


### PR DESCRIPTION
As some servers may only want specific entities to be picked up by
serena, this commit creates a configurable blacklist that contains the
namespaced ids of the entity types that may not be interacted with
through serena logic.

Resolves: #6